### PR TITLE
Patch for OTP25

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -4,7 +4,7 @@ efuse.o: efuse.c efuse_defs.h
 	gcc -c -Wall -std=gnu99 -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse -shared -g -Wall -fPIC -MMD  -I"/usr/lib/erlang/lib/erl_interface-3.10.1/include" -I"/usr/lib/erlang/erts-9.2/include" efuse.c -o efuse.o
 
 efuse: efuse.o
-	gcc efuse.o  -lerl_interface -lei -pthread -lnsl -lfuse -lrt -ldl -o efuse
+	gcc efuse.o -pthread -lnsl -lfuse -lrt -ldl -o efuse
 	cp efuse ../priv/
 
 clean:


### PR DESCRIPTION
I don't think those libs are needed anymore.. (are they?)

I installed via asdf and had trouble explaining the LD path. Removing them didn't seem to have an impact